### PR TITLE
Add response_format for generate text api

### DIFF
--- a/include/ai/types/generate_options.h
+++ b/include/ai/types/generate_options.h
@@ -18,6 +18,7 @@ struct GenerateOptions {
   std::string system;
   std::string prompt;
   Messages messages;
+  std::optional<nlohmann::json> response_format {};
   std::optional<int> max_tokens;
   std::optional<double> temperature;
   std::optional<double> top_p;
@@ -45,6 +46,15 @@ struct GenerateOptions {
       : model(std::move(model_name)),
         system(std::move(system_prompt)),
         prompt(std::move(user_prompt)) {}
+
+  GenerateOptions(std::string model_name,
+                  std::string system_prompt,
+                  std::string user_prompt,
+                  std::optional<nlohmann::json> response_format_)
+      : model(std::move(model_name)),
+        system(std::move(system_prompt)),
+        prompt(std::move(user_prompt)),
+        response_format(std::move(response_format_)) {}
 
   GenerateOptions(std::string model_name, Messages conversation)
       : model(std::move(model_name)), messages(std::move(conversation)) {}

--- a/src/providers/openai/openai_request_builder.cpp
+++ b/src/providers/openai/openai_request_builder.cpp
@@ -11,6 +11,8 @@ nlohmann::json OpenAIRequestBuilder::build_request_json(
   nlohmann::json request{{"model", options.model},
                          {"messages", nlohmann::json::array()}};
 
+  if (options.response_format)
+    request["response_format"] = options.response_format.value();
   // Build messages array
   if (!options.messages.empty()) {
     // Use provided messages


### PR DESCRIPTION
The generate_text API supports the response_format parameter to control the format of model output. This enables structured outputs, which are essential for implementing AI-powered functions within ClickHouse.