### PR TITLE
Changed default: enable SSL certificate verification by default

### DIFF
--- a/src/http/http_request_handler.h
+++ b/src/http/http_request_handler.h
@@ -19,7 +19,7 @@ struct HttpConfig {
   bool use_ssl = true;
   int connection_timeout_sec = 30;
   int read_timeout_sec = 120;
-  bool verify_ssl_cert = false;
+  bool verify_ssl_cert = true;
 
   // Retry configuration
   retry::RetryConfig retry_config;


### PR DESCRIPTION
Changed verify_ssl_cert default from false to true to protect against man-in-the-middle attacks. Users can still explicitly disable if needed for testing with self-signed certificates.

Fixes #8