### PR TITLE
feat: ai gen extension for postgres based on clickhouse ai sdk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,22 @@ set(ANTHROPIC_SOURCES
 target_sources(ai-sdk-cpp-openai PRIVATE ${OPENAI_SOURCES})
 target_sources(ai-sdk-cpp-anthropic PRIVATE ${ANTHROPIC_SOURCES})
 
+set(GEMINI_SOURCES
+    src/providers/gemini/gemini_client.cpp
+    src/providers/gemini/gemini_request_builder.cpp
+    src/providers/gemini/gemini_response_parser.cpp
+    src/providers/gemini/gemini_factory.cpp
+)
+
+add_library(ai-sdk-cpp-gemini)
+add_library(ai::gemini ALIAS ai-sdk-cpp-gemini)
+target_sources(ai-sdk-cpp-gemini PRIVATE ${GEMINI_SOURCES})
+configure_ai_component(ai-sdk-cpp-gemini)
+
+# Link gemini into main interface
+target_link_libraries(ai-sdk-cpp INTERFACE ai::gemini)
+target_compile_definitions(ai-sdk-cpp INTERFACE AI_SDK_HAS_GEMINI=1)
+
 # Link dependencies
 target_link_libraries(ai-sdk-cpp-core
     PUBLIC
@@ -135,6 +151,22 @@ foreach(provider openai anthropic)
     )
 endforeach()
 
+# Configure gemini component
+target_link_libraries(ai-sdk-cpp-gemini
+    PUBLIC
+        ai::core
+        nlohmann_json::nlohmann_json
+    PRIVATE
+        $<BUILD_INTERFACE:httplib::httplib>
+        $<BUILD_INTERFACE:concurrentqueue>
+)
+target_compile_definitions(ai-sdk-cpp-gemini
+    PUBLIC
+        AI_SDK_HAS_GEMINI=1
+    PRIVATE
+        ${HTTPLIB_COMPILE_DEFS}
+)
+
 # Core needs HTTP definitions too
 target_compile_definitions(ai-sdk-cpp-core
     PRIVATE
@@ -157,7 +189,7 @@ target_compile_definitions(ai-sdk-cpp
 )
 
 # List of all concrete component targets
-set(COMPONENT_TARGETS ai-sdk-cpp-core ai-sdk-cpp-openai ai-sdk-cpp-anthropic)
+set(COMPONENT_TARGETS ai-sdk-cpp-core ai-sdk-cpp-openai ai-sdk-cpp-anthropic ai-sdk-cpp-gemini)
 
 # Common compile options
 if(MSVC)

--- a/contrib/pg_gen_query/CMakeLists.txt
+++ b/contrib/pg_gen_query/CMakeLists.txt
@@ -1,0 +1,78 @@
+cmake_minimum_required(VERSION 3.16)
+project(pg_gen_query LANGUAGES C CXX)
+
+find_package(PostgreSQL REQUIRED)
+
+## The ai-sdk-cpp repo may provide an in-tree CMake alias `ai::sdk`.
+## When the SDK is installed it exports targets with the `ai::` prefix
+## such as `ai::ai-sdk-cpp`. Check both and prefer the installed name.
+## If ai-sdk-cpp was installed to a prefix, try to find the package so the
+## exported targets (e.g. `ai::ai-sdk-cpp`) become available to this project.
+## Ensure `find_dependency` macro is available for the package config file.
+include(CMakeFindDependencyMacro)
+find_package(ai-sdk-cpp QUIET)
+
+# Find common system libraries required by the SDK
+find_package(OpenSSL QUIET)
+find_package(ZLIB QUIET)
+find_library(BROTLI_DEC_LIB brotlidec HINTS ${CMAKE_PREFIX_PATH} PATH_SUFFIXES lib)
+find_library(BROTLI_COMMON_LIB brotlicommon HINTS ${CMAKE_PREFIX_PATH} PATH_SUFFIXES lib)
+
+## The ai-sdk-cpp repo may also provide an in-tree CMake alias `ai::sdk`.
+## Prefer the installed target names when available.
+if(TARGET ai::ai-sdk-cpp)
+  set(AI_SDK_ALIAS_TARGET ai::ai-sdk-cpp)
+elseif(TARGET ai::sdk)
+  set(AI_SDK_ALIAS_TARGET ai::sdk)
+else()
+  message(STATUS "ai::sdk or ai::ai-sdk-cpp target not found. Please set AI_SDK_TARGET to your SDK target name.")
+endif()
+
+set(SOURCE_FILES pg_gen_query.cpp)
+
+add_library(pg_gen_query SHARED ${SOURCE_FILES})
+target_include_directories(pg_gen_query PRIVATE ${PostgreSQL_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/../../include ${CMAKE_SOURCE_DIR}/src)
+target_compile_features(pg_gen_query PRIVATE cxx_std_17)
+
+if(TARGET ${AI_SDK_ALIAS_TARGET})
+  target_link_libraries(pg_gen_query PRIVATE ${PostgreSQL_LIBRARIES} ${AI_SDK_ALIAS_TARGET})
+  # Link common transitive dependencies used by ai-sdk-cpp so symbols
+  # from OpenSSL, brotli, zlib and httplib are available at link time.
+  if(TARGET OpenSSL::SSL)
+    target_link_libraries(pg_gen_query PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+  endif()
+  if(TARGET httplib::httplib)
+    target_link_libraries(pg_gen_query PRIVATE httplib::httplib)
+  endif()
+  if(TARGET concurrentqueue)
+    target_link_libraries(pg_gen_query PRIVATE concurrentqueue)
+  endif()
+  if(ZLIB_FOUND)
+    target_link_libraries(pg_gen_query PRIVATE ZLIB::ZLIB)
+  endif()
+  if(BROTLI_DEC_LIB)
+    target_link_libraries(pg_gen_query PRIVATE ${BROTLI_DEC_LIB})
+  endif()
+  if(BROTLI_COMMON_LIB)
+    target_link_libraries(pg_gen_query PRIVATE ${BROTLI_COMMON_LIB})
+  endif()
+else()
+  # User must provide AI_SDK_TARGET when configuring
+  if(DEFINED AI_SDK_TARGET)
+    target_link_libraries(pg_gen_query PRIVATE ${PostgreSQL_LIBRARIES} ${AI_SDK_TARGET})
+  else()
+    message(FATAL_ERROR "AI SDK CMake target not found. Define AI_SDK_TARGET when running cmake.")
+  endif()
+endif()
+
+set_target_properties(pg_gen_query PROPERTIES
+  PREFIX ""
+  SUFFIX ".so"
+)
+
+# On macOS allow undefined symbols (Postgres provides them at runtime)
+if(APPLE)
+  set_target_properties(pg_gen_query PROPERTIES
+    LINK_FLAGS "-undefined dynamic_lookup"
+  )
+endif()

--- a/contrib/pg_gen_query/README.md
+++ b/contrib/pg_gen_query/README.md
@@ -1,0 +1,78 @@
+Usage
+-
+- Set provider API key (GUC) in your psql session and call `pg_gen_query` with a natural language prompt.
+
+```sql
+SET pg_gen_query.gemini_api_key = 'YOUR_GEMINI_API_KEY';
+SELECT pg_gen_query('number of events from Texas');
+```
+
+Features
+-
+- Schema-aware prompts: includes a concise list of non-system tables and columns in the prompt.
+- Provider support: Gemini (primary) with optional fallbacks to OpenAI/Anthropic.
+- Auto-execute read-only: executes returned SQL only when it begins with `SELECT`.
+- Preview-only: returns generated SQL without executing when not a `SELECT`.
+
+<<<<<<< Updated upstream
+Build & Install
+-
+- From `contrib/pg_gen_query`:
+
+```fish
+mkdir -p build && cd build
+cmake .. -DCMAKE_PREFIX_PATH=/path/to/ai-sdk-cpp/build/install
+cmake --build . --config Release
+```
+
+- Copy the built library into your Postgres extension directory (example Homebrew path):
+
+```fish
+cp build/pg_gen_query.so /opt/homebrew/lib/postgresql@14/
+```
+
+- Then in `psql` create/load the extension and set GUCs as needed.
+
+Examples (exact commands and results)
+
+Run the setup and insert the sample rows (API key masked):
+
+```fish
+psql -d postgres -c "SET client_min_messages = 'log'; SET pg_gen_query.gemini_model = 'gemini-2.0-flash'; SET pg_gen_query.gemini_api_key = 'YOUR_GEMINI_API_KEY'; DROP TABLE IF EXISTS events; CREATE TABLE events(id serial primary key, name text, state text); TRUNCATE events; INSERT INTO events(name,state) VALUES('Concert','Texas'),('Meetup','Texas'),('Conference','California'),('Webinar','Texas'),('Hackathon','New York');"
+```
+
+Run each example query (these are the exact commands used during testing) and the expected outputs shown after each:
+
+```sql
+-- 1) Count Texas events
+SELECT pg_gen_query('number of events from Texas');
+-- Generated SQL (example):
+-- SELECT COUNT(*) AS count FROM events WHERE state = 'Texas';
+-- Result (example):
+-- count
+-- ------
+-- 3
+
+-- 2) List events in California
+SELECT pg_gen_query('list events in California');
+-- Generated SQL (example):
+-- SELECT * FROM events WHERE state = 'California';
+-- Result (example):
+-- id | name       | state
+-- ---+------------+-----------
+-- 3  | Conference | California
+
+-- 3) Names of events in New York
+SELECT pg_gen_query('return the names of events in New York');
+-- Generated SQL (example):
+-- SELECT name FROM events WHERE state = 'New York';
+-- Result (example):
+-- name
+-- -------
+-- Hackathon
+```
+
+
+
+=======
+>>>>>>> Stashed changes

--- a/contrib/pg_gen_query/README.md
+++ b/contrib/pg_gen_query/README.md
@@ -14,7 +14,6 @@ Features
 - Auto-execute read-only: executes returned SQL only when it begins with `SELECT`.
 - Preview-only: returns generated SQL without executing when not a `SELECT`.
 
-<<<<<<< Updated upstream
 Build & Install
 -
 - From `contrib/pg_gen_query`:
@@ -74,5 +73,3 @@ SELECT pg_gen_query('return the names of events in New York');
 
 
 
-=======
->>>>>>> Stashed changes

--- a/contrib/pg_gen_query/docker-compose.yml
+++ b/contrib/pg_gen_query/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      - GEMINI_BASE_URL=${GEMINI_BASE_URL}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./pg_lib:/usr/local/lib/pg_ext:rw
+    healthcheck:
+      test: ["CMD-SHELL","pg_isready -U ${POSTGRES_USER}" ]
+      interval: 5s
+      retries: 5

--- a/contrib/pg_gen_query/pg_gen_query--1.0.sql
+++ b/contrib/pg_gen_query/pg_gen_query--1.0.sql
@@ -1,0 +1,7 @@
+CREATE FUNCTION pg_gen_query(text) RETURNS text
+  AS '$libdir/pg_gen_query', 'pg_gen_query'
+  LANGUAGE c STRICT;
+
+CREATE FUNCTION pg_ai_provider() RETURNS text
+  AS '$libdir/pg_gen_query', 'pg_ai_provider'
+  LANGUAGE c STRICT;

--- a/contrib/pg_gen_query/pg_gen_query.control
+++ b/contrib/pg_gen_query/pg_gen_query.control
@@ -1,0 +1,4 @@
+# pg_gen_query extension
+comment = 'Generate SQL from natural language using ClickHouse AI SDK'
+default_version = '1.0'
+module_pathname = '$libdir/pg_gen_query'

--- a/contrib/pg_gen_query/pg_gen_query.cpp
+++ b/contrib/pg_gen_query/pg_gen_query.cpp
@@ -1,0 +1,306 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <postgres.h>
+#include <fmgr.h>
+#include <utils/builtins.h>
+#include <utils/guc.h>
+#include <executor/spi.h>
+#include <access/htup_details.h>
+#ifdef PG_MODULE_MAGIC
+PG_MODULE_MAGIC;
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+#include <ai/ai.h>
+
+// C++ headers must be included outside extern "C"
+#include <regex>
+#include <sstream>
+#include <algorithm>
+#include <cctype>
+
+/* GUCs to allow configuring API keys from Postgres instead of process env */
+static char *pg_gen_query_gemini_api_key = NULL;
+static char *pg_gen_query_openai_api_key = NULL;
+static char *pg_gen_query_anthropic_api_key = NULL;
+static char *pg_gen_query_gemini_model = NULL;
+
+extern "C" void _PG_init(void);
+
+extern "C" PGDLLEXPORT Datum pg_gen_query(PG_FUNCTION_ARGS);
+extern "C" PGDLLEXPORT Datum pg_ai_provider(PG_FUNCTION_ARGS);
+
+extern "C" {
+PG_FUNCTION_INFO_V1(pg_gen_query);
+PG_FUNCTION_INFO_V1(pg_ai_provider);
+}
+
+Datum pg_gen_query(PG_FUNCTION_ARGS) {
+  text* prompt_text = PG_GETARG_TEXT_PP(0);
+  char* prompt_cstr = text_to_cstring(prompt_text);
+
+  // Gather DB schema information (tables and columns) via SPI.
+  auto get_schema_description = [&]() -> std::string {
+    std::ostringstream out;
+    if (SPI_connect() != SPI_OK_CONNECT) return "";
+    const char* q = "SELECT table_schema, table_name, column_name, data_type FROM information_schema.columns WHERE table_schema NOT IN ('pg_catalog','information_schema') ORDER BY table_schema, table_name, ordinal_position";
+    int rc = SPI_execute(q, true, 0);
+    if (rc == SPI_OK_SELECT && SPI_processed > 0) {
+      TupleDesc tup = SPI_tuptable->tupdesc;
+      SPITupleTable *tuptable = SPI_tuptable;
+      std::string last_table;
+      for (uint64_t i = 0; i < (uint64_t)SPI_processed; ++i) {
+        HeapTuple ht = tuptable->vals[i];
+        char* schema = SPI_getvalue(ht, tup, 1);
+        char* tbl = SPI_getvalue(ht, tup, 2);
+        char* col = SPI_getvalue(ht, tup, 3);
+        char* dt = SPI_getvalue(ht, tup, 4);
+        if (!schema || !tbl || !col || !dt) continue;
+        std::string table_full = std::string(schema) + "." + std::string(tbl);
+        if (table_full != last_table) {
+          out << table_full << "\n";
+          last_table = table_full;
+        }
+        out << "  - " << col << " : " << dt << "\n";
+      }
+    }
+    SPI_finish();
+    return out.str();
+  };
+
+  std::string schema_desc = get_schema_description();
+
+  std::string user_prompt = std::string("Database schema:\n") + schema_desc + "\nTranslate the following natural language into a single PostgreSQL SELECT query. Return only the SQL (no explanation) and use PostgreSQL syntax (single quotes for string literals):\n" + std::string(prompt_cstr);
+  // Prefer keys supplied via Postgres GUCs, fall back to environment-based
+  // try_create_client() for each provider.
+  ai::Client client;
+  try {
+    ereport(LOG, (errmsg("pg_gen_query GUCs: gemini_key='%s' openai_key='%s' anthropic_key='%s' gemini_model='%s'",
+                        pg_gen_query_gemini_api_key ? pg_gen_query_gemini_api_key : "(null)",
+                        pg_gen_query_openai_api_key ? pg_gen_query_openai_api_key : "(null)",
+                        pg_gen_query_anthropic_api_key ? pg_gen_query_anthropic_api_key : "(null)",
+                        pg_gen_query_gemini_model ? pg_gen_query_gemini_model : "(null)")));
+
+    if (pg_gen_query_gemini_api_key && pg_gen_query_gemini_api_key[0] != '\0') {
+      ereport(LOG, (errmsg("pg_gen_query: calling gemini::create_client with key length=%d", (int)strlen(pg_gen_query_gemini_api_key))));
+      client = ai::gemini::create_client(std::string(pg_gen_query_gemini_api_key));
+      ereport(LOG, (errmsg("pg_gen_query: returned from gemini::create_client, client.is_valid()=%d", client.is_valid())));
+    } else {
+      ereport(LOG, (errmsg("pg_gen_query: calling gemini::try_create_client()")));
+      auto opt_gemini = ai::gemini::try_create_client();
+      if (opt_gemini.has_value()) client = std::move(*opt_gemini);
+      ereport(LOG, (errmsg("pg_gen_query: returned from try_create_client, client.is_valid()=%d", client.is_valid())));
+    }
+
+    ereport(LOG, (errmsg("After gemini attempt: client valid=%d provider='%s' default_model='%s' config='%s'",
+              client.is_valid(),
+              client.provider_name().c_str(),
+              client.default_model().c_str(),
+              client.config_info().c_str())));
+
+    if (!client.is_valid()) {
+      if (pg_gen_query_openai_api_key && pg_gen_query_openai_api_key[0] != '\0') {
+        client = ai::openai::create_client(std::string(pg_gen_query_openai_api_key));
+      } else {
+        auto opt_openai = ai::openai::try_create_client();
+        if (opt_openai.has_value()) client = std::move(*opt_openai);
+      }
+    }
+
+    if (!client.is_valid()) {
+      if (pg_gen_query_anthropic_api_key && pg_gen_query_anthropic_api_key[0] != '\0') {
+        client = ai::anthropic::create_client(std::string(pg_gen_query_anthropic_api_key));
+      } else {
+        auto opt_anthropic = ai::anthropic::try_create_client();
+        if (opt_anthropic.has_value()) client = std::move(*opt_anthropic);
+      }
+    }
+  } catch (const std::exception &e) {
+    ereport(ERROR, (errmsg("AI client configuration error: %s", e.what())));
+    PG_RETURN_NULL();
+  }
+
+  if (!client.is_valid()) {
+    ereport(ERROR, (errmsg("No AI provider configured. Set GEMINI_API_KEY or OPENAI_API_KEY or ANTHROPIC_API_KEY.")));
+    PG_RETURN_NULL();
+  }
+
+  ai::GenerateOptions options;
+  options.model = client.default_model();
+  // Allow overriding model via GUC only
+  if (pg_gen_query_gemini_model && pg_gen_query_gemini_model[0] != '\0') {
+    options.model = std::string(pg_gen_query_gemini_model);
+  }
+  if (options.model.empty()) options.model = ai::openai::models::kDefaultModel;
+  options.prompt = user_prompt;
+
+  auto result = client.generate_text(options);
+
+  if (!result) {
+    std::string err = result.error_message();
+    if (err.empty()) err = "unknown error";
+    ereport(LOG, (errmsg("pg_gen_query: AI generation raw error: %s", err.c_str())));
+    ereport(ERROR, (errmsg("AI generation failed: %s", err.c_str())));
+    PG_RETURN_NULL();
+  }
+
+  std::string generated = result.text;
+
+  // Strip code fences if present (simple match of ```...```)
+  std::regex fence_re(R"(```(?:sql)?\n([\s\S]*?)\n```)" , std::regex::icase);
+  std::smatch m;
+  if (std::regex_search(generated, m, fence_re) && m.size() > 1) {
+    generated = m[1].str();
+  }
+
+  // Basic sanitization: prefer single quotes for string literals
+  try {
+    std::regex string_eq_re(R"((=)\s*\"([^\"]*)\")");
+    generated = std::regex_replace(generated, string_eq_re, "$1 '$2'");
+  } catch (...) {
+    // Ignore regex issues and use generated as-is
+  }
+
+  // Trim leading whitespace
+  auto ltrim = [](std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) { return !std::isspace(ch); }));
+  };
+  auto rtrim = [](std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), s.end());
+  };
+  ltrim(generated);
+  rtrim(generated);
+
+  // Only execute if the model returned a SELECT statement (read-only)
+  std::string generated_upper = generated;
+  std::transform(generated_upper.begin(), generated_upper.end(), generated_upper.begin(), ::toupper);
+  if (generated_upper.rfind("SELECT", 0) == 0) {
+    // Execute as read-only via SPI
+    if (SPI_connect() != SPI_OK_CONNECT) {
+      ereport(ERROR, (errmsg("pg_gen_query: SPI_connect failed")));
+      PG_RETURN_NULL();
+    }
+    int rc = SPI_execute(generated.c_str(), true, 0);
+    if (rc != SPI_OK_SELECT && rc != SPI_OK_SELINTO) {
+      SPI_finish();
+      ereport(ERROR, (errmsg("pg_gen_query: SQL execution failed (rc=%d)", rc)));
+      PG_RETURN_NULL();
+    }
+    // Build a textual representation of the result
+    std::ostringstream outbuf;
+    if (SPI_processed > 0 && SPI_tuptable) {
+      TupleDesc tup = SPI_tuptable->tupdesc;
+      SPITupleTable *tuptable = SPI_tuptable;
+      // Header
+      for (int col = 1; col <= tup->natts; ++col) {
+        if (col > 1) outbuf << '\t';
+        outbuf << NameStr(tup->attrs[col-1].attname);
+      }
+      outbuf << '\n';
+      for (uint64_t i = 0; i < (uint64_t)SPI_processed; ++i) {
+        HeapTuple ht = tuptable->vals[i];
+        for (int col = 1; col <= tup->natts; ++col) {
+          if (col > 1) outbuf << '\t';
+          char *val = SPI_getvalue(ht, tup, col);
+          outbuf << (val ? val : "\\N");
+        }
+        outbuf << '\n';
+      }
+    }
+    SPI_finish();
+    std::string final_out = outbuf.str();
+    text* out = cstring_to_text(final_out.c_str());
+    PG_RETURN_POINTER(out);
+  }
+
+  // If not a SELECT, don't execute; return the SQL string for inspection
+  text* out = cstring_to_text(generated.c_str());
+  PG_RETURN_POINTER(out);
+}
+
+Datum pg_ai_provider(PG_FUNCTION_ARGS) {
+  ai::Client client;
+  try {
+    if (pg_gen_query_gemini_api_key && pg_gen_query_gemini_api_key[0] != '\0') {
+      client = ai::gemini::create_client(std::string(pg_gen_query_gemini_api_key));
+    } else {
+      auto opt_gemini = ai::gemini::try_create_client();
+      if (opt_gemini.has_value()) client = std::move(*opt_gemini);
+    }
+
+    if (!client.is_valid()) {
+      if (pg_gen_query_openai_api_key && pg_gen_query_openai_api_key[0] != '\0') {
+        client = ai::openai::create_client(std::string(pg_gen_query_openai_api_key));
+      } else {
+        auto opt_openai = ai::openai::try_create_client();
+        if (opt_openai.has_value()) client = std::move(*opt_openai);
+      }
+    }
+
+    if (!client.is_valid()) {
+      if (pg_gen_query_anthropic_api_key && pg_gen_query_anthropic_api_key[0] != '\0') {
+        client = ai::anthropic::create_client(std::string(pg_gen_query_anthropic_api_key));
+      } else {
+        auto opt_anthropic = ai::anthropic::try_create_client();
+        if (opt_anthropic.has_value()) client = std::move(*opt_anthropic);
+      }
+    }
+  } catch (const std::exception &e) {
+    ereport(ERROR, (errmsg("AI client configuration error: %s", e.what())));
+    PG_RETURN_NULL();
+  }
+
+  std::string provider = client.is_valid() ? client.provider_name() : std::string("none");
+  text* out = cstring_to_text(provider.c_str());
+  PG_RETURN_POINTER(out);
+}
+
+/* Initialize GUC variables */
+extern "C" void _PG_init(void) {
+  DefineCustomStringVariable("pg_gen_query.gemini_api_key",
+                             "Gemini API key for pg_gen_query",
+                             NULL,
+                             &pg_gen_query_gemini_api_key,
+                             "",
+                             PGC_SUSET,
+                             0,
+                             NULL,
+                             NULL,
+                             NULL);
+
+  DefineCustomStringVariable("pg_gen_query.openai_api_key",
+                             "OpenAI API key for pg_gen_query",
+                             NULL,
+                             &pg_gen_query_openai_api_key,
+                             "",
+                             PGC_SUSET,
+                             0,
+                             NULL,
+                             NULL,
+                             NULL);
+
+  DefineCustomStringVariable("pg_gen_query.gemini_model",
+                             "Default Gemini model for pg_gen_query",
+                             NULL,
+                             &pg_gen_query_gemini_model,
+                             "gemini-2.0-flash",
+                             PGC_USERSET,
+                             0,
+                             NULL,
+                             NULL,
+                             NULL);
+
+  DefineCustomStringVariable("pg_gen_query.anthropic_api_key",
+                             "Anthropic API key for pg_gen_query",
+                             NULL,
+                             &pg_gen_query_anthropic_api_key,
+                             "",
+                             PGC_SUSET,
+                             0,
+                             NULL,
+                             NULL,
+                             NULL);
+}

--- a/contrib/pg_gen_query/register_function.sql
+++ b/contrib/pg_gen_query/register_function.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION pg_gen_query(text) RETURNS text
+  AS '/full/path/pg_gen_query.so', 'pg_gen_query'
+  LANGUAGE c STRICT;
+
+CREATE OR REPLACE FUNCTION pg_ai_provider() RETURNS text
+  AS '/full/path/pg_gen_query.so', 'pg_ai_provider'
+  LANGUAGE c STRICT;

--- a/include/ai/ai.h
+++ b/include/ai/ai.h
@@ -12,6 +12,8 @@
 #include "anthropic.h"
 #endif
 
+#include "gemini.h"
+
 // Type definitions
 #include "types/client.h"
 #include "types/enums.h"

--- a/include/ai/gemini.h
+++ b/include/ai/gemini.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include "types/client.h"
+
+namespace ai {
+namespace gemini {
+
+// Factory functions implemented in the SDK library (src/providers/gemini)
+Client create_client();
+Client create_client(const std::string& api_key);
+Client create_client(const std::string& api_key, const std::string& base_url);
+
+std::optional<Client> try_create_client();
+
+}  // namespace gemini
+}  // namespace ai
+

--- a/src/providers/base_provider_client.cpp
+++ b/src/providers/base_provider_client.cpp
@@ -23,11 +23,9 @@ BaseProviderClient::BaseProviderClient(
 
   http_handler_ = std::make_unique<http::HttpRequestHandler>(http_config);
 
-  ai::logger::log_debug(
-      R"(BaseProviderClient initialized - base_url: {},
-     completions_endpoint: {}, embeddings_endpoint: {})",
-      config.base_url, config.completions_endpoint_path,
-      config.embeddings_endpoint_path);
+  ai::logger::log_info("BaseProviderClient initialized - api_key_length={} base_url={} completions_endpoint={} embeddings_endpoint={}",
+                       config.api_key.size(), config.base_url, config.completions_endpoint_path,
+                       config.embeddings_endpoint_path);
 }
 
 GenerateResult BaseProviderClient::generate_text(

--- a/src/providers/gemini/gemini_client.cpp
+++ b/src/providers/gemini/gemini_client.cpp
@@ -1,0 +1,158 @@
+#include "gemini_client.h"
+
+#include "ai/logger.h"
+#include "providers/gemini/gemini_request_builder.h"
+#include "providers/gemini/gemini_response_parser.h"
+
+#include <algorithm>
+#include <memory>
+
+namespace ai {
+namespace gemini {
+
+GeminiClient::GeminiClient(const std::string& api_key,
+                           const std::string& base_url)
+    : BaseProviderClient(
+          providers::ProviderConfig{
+              .api_key = api_key,
+              .base_url = base_url,
+              .completions_endpoint_path = "/v1/chat/completions",
+              .embeddings_endpoint_path = "/v1/embeddings",
+              .auth_header_name = "Authorization",
+              .auth_header_prefix = "Bearer ",
+              .extra_headers = {}},
+                std::make_unique<::ai::gemini::GeminiRequestBuilder>(providers::ProviderConfig{
+              .api_key = api_key,
+              .base_url = base_url,
+              .completions_endpoint_path = "/v1/chat/completions",
+              .embeddings_endpoint_path = "/v1/embeddings",
+              .auth_header_name = "Authorization",
+              .auth_header_prefix = "Bearer ",
+              .extra_headers = {}}),
+                std::make_unique<::ai::gemini::GeminiResponseParser>()) {
+  ai::logger::log_debug("Gemini client initialized with base_url: {}", base_url);
+}
+
+GeminiClient::GeminiClient(const std::string& api_key,
+                           const std::string& base_url,
+                           const retry::RetryConfig& retry_config)
+    : BaseProviderClient(
+          providers::ProviderConfig{
+              .api_key = api_key,
+              .base_url = base_url,
+              .completions_endpoint_path = "/v1/chat/completions",
+              .embeddings_endpoint_path = "/v1/embeddings",
+              .auth_header_name = "Authorization",
+              .auth_header_prefix = "Bearer ",
+              .extra_headers = {},
+              .retry_config = retry_config},
+                std::make_unique<::ai::gemini::GeminiRequestBuilder>(providers::ProviderConfig{
+              .api_key = api_key,
+              .base_url = base_url,
+              .completions_endpoint_path = "/v1/chat/completions",
+              .embeddings_endpoint_path = "/v1/embeddings",
+              .auth_header_name = "Authorization",
+              .auth_header_prefix = "Bearer ",
+              .extra_headers = {} ,
+              .retry_config = retry_config}),
+                std::make_unique<::ai::gemini::GeminiResponseParser>()) {
+  ai::logger::log_debug(
+      "Gemini client initialized with base_url: {} and custom retry config",
+      base_url);
+}
+
+StreamResult GeminiClient::stream_text(const StreamOptions& options) {
+  ai::logger::log_debug("Starting Gemini text streaming - model: {}, prompt length: {}", options.model, options.prompt.length());
+
+  auto request_json = request_builder_->build_request_json(options);
+  request_json["stream"] = true;
+  auto headers = request_builder_->build_headers(config_);
+  headers.emplace("Accept", "text/event-stream");
+
+  // Not implementing streaming specifics here; reuse base behavior if needed
+  ai::logger::log_info("Gemini streaming not fully implemented; returning empty StreamResult");
+  return StreamResult();
+}
+
+GenerateResult GeminiClient::generate_text_single_step(const GenerateOptions& options) {
+  // Build request JSON using the provider-specific builder
+  auto request_json = request_builder_->build_request_json(options);
+  std::string json_body = request_json.dump();
+  ai::logger::log_debug("Gemini single-step request JSON: {}", json_body);
+
+  // Build headers (this will add X-goog-api-key for Google GL base_url)
+  auto headers = request_builder_->build_headers(config_);
+
+  // Build the GL-specific path: /v1beta/models/{model}:generateContent
+  std::string model = options.model.empty() ? default_model() : options.model;
+  std::string path = "/v1beta/models/" + model + ":generateContent";
+
+  // Log the outgoing request path and headers at info level so Postgres
+  // logs capture them even if debug is not enabled.
+  std::string headers_str;
+  size_t header_chars = 0;
+  for (const auto& [k, v] : headers) {
+    if (!headers_str.empty()) headers_str += ", ";
+    headers_str += k + ":" + (v.size() > 64 ? v.substr(0, 64) + "...[trunc]" : v);
+    header_chars += k.size() + v.size();
+    if (header_chars > 1024) { headers_str += "...[trunc]"; break; }
+  }
+  ai::logger::log_info("Gemini request -> path='{}' headers='{}' body_size={}", path, headers_str, json_body.size());
+
+  // Make the request using application/json
+  auto result = http_handler_->post(path, headers, json_body, "application/json");
+
+  ai::logger::log_info("Gemini request returned: success={} provider_metadata='{}' error_size={}", result.is_success(), result.provider_metadata.value_or(""), result.error.has_value() ? result.error->size() : 0);
+
+  if (!result.is_success()) {
+    if (result.provider_metadata.has_value()) {
+      int status_code = std::stoi(result.provider_metadata.value());
+      return response_parser_->parse_error_completion_response(
+          status_code, result.error.value_or(""));
+    }
+    return result;
+  }
+
+  // Parse JSON response
+  nlohmann::json json_response;
+  try {
+    json_response = nlohmann::json::parse(result.text);
+  } catch (const nlohmann::json::exception& e) {
+    ai::logger::log_error("Failed to parse Gemini response JSON: {}", e.what());
+    // Include a truncated version of the raw response in the returned error
+    const size_t kMaxErrBody = 4096;
+    std::string truncated = result.text.substr(0, std::min(kMaxErrBody, result.text.size()));
+    std::string err = std::string("Failed to parse response: ") + e.what() + "; raw_response=" + truncated + (result.text.size() > kMaxErrBody ? "...[truncated]" : "");
+    return GenerateResult(err);
+  }
+
+  auto parsed_result = response_parser_->parse_success_completion_response(json_response);
+  if (!parsed_result) {
+    const size_t kMaxErrBody = 4096;
+    std::string raw = json_response.dump();
+    std::string truncated = raw.substr(0, std::min(kMaxErrBody, raw.size()));
+    std::string err = parsed_result.error_message() + "; raw_response=" + truncated + (raw.size() > kMaxErrBody ? "...[truncated]" : "");
+    return GenerateResult(err);
+  }
+  return parsed_result;
+}
+
+std::string GeminiClient::provider_name() const { return "gemini"; }
+
+std::vector<std::string> GeminiClient::supported_models() const {
+  return {"gemini-2.0-flash", "gemini-2.0"};
+}
+
+bool GeminiClient::supports_model(const std::string& model_name) const {
+  auto models = supported_models();
+  return std::find(models.begin(), models.end(), model_name) != models.end();
+}
+
+std::string GeminiClient::config_info() const {
+  return "Gemini API (base_url: " + config_.base_url + ")";
+}
+
+std::string GeminiClient::default_model() const { return "gemini-2.0-flash"; }
+
+}  // namespace gemini
+}  // namespace ai

--- a/src/providers/gemini/gemini_client.h
+++ b/src/providers/gemini/gemini_client.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "ai/retry/retry_policy.h"
+#include "ai/types/stream_options.h"
+#include "providers/base_provider_client.h"
+
+#include <string>
+#include <vector>
+
+namespace ai {
+namespace gemini {
+
+class GeminiClient : public providers::BaseProviderClient {
+ public:
+  explicit GeminiClient(const std::string& api_key,
+                        const std::string& base_url = "https://api.openai.com");
+
+  explicit GeminiClient(const std::string& api_key,
+                        const std::string& base_url,
+                        const retry::RetryConfig& retry_config);
+
+  StreamResult stream_text(const StreamOptions& options) override;
+  GenerateResult generate_text_single_step(const GenerateOptions& options) override;
+  std::string provider_name() const override;
+  std::vector<std::string> supported_models() const override;
+  bool supports_model(const std::string& model_name) const override;
+  std::string config_info() const override;
+  std::string default_model() const override;
+};
+
+}  // namespace gemini
+}  // namespace ai

--- a/src/providers/gemini/gemini_factory.cpp
+++ b/src/providers/gemini/gemini_factory.cpp
@@ -1,0 +1,61 @@
+#include "gemini_factory.h"
+
+#include "ai/errors.h"
+#include "gemini_client.h"
+#include "ai/logger.h"
+
+#include <cstdlib>
+#include <memory>
+#include <optional>
+
+namespace ai {
+namespace gemini {
+
+namespace {
+constexpr const char* kDefaultBaseUrl = "https://generativelanguage.googleapis.com";
+
+std::string get_api_key_or_default(const std::string& api_key) {
+  if (!api_key.empty()) {
+    return api_key;
+  }
+
+  const char* env_api_key = std::getenv("GEMINI_API_KEY");
+  if (!env_api_key) {
+    throw ConfigurationError(
+        "API key not provided and GEMINI_API_KEY environment variable not set");
+  }
+  return env_api_key;
+}
+
+std::string get_base_url_or_default(const std::string& base_url) {
+  return base_url.empty() ? kDefaultBaseUrl : base_url;
+}
+}  // namespace
+
+Client create_client() {
+  auto key = get_api_key_or_default("");
+  ai::logger::log_info("gemini_factory::create_client() called with api_key length={} base_url={}", key.size(), kDefaultBaseUrl);
+  return Client(std::make_unique<GeminiClient>(key, kDefaultBaseUrl));
+}
+
+Client create_client(const std::string& api_key) {
+  auto key = get_api_key_or_default(api_key);
+  ai::logger::log_info("gemini_factory::create_client(api_key) called with api_key length={} base_url={}", key.size(), kDefaultBaseUrl);
+  return Client(std::make_unique<GeminiClient>(key, kDefaultBaseUrl));
+}
+
+Client create_client(const std::string& api_key, const std::string& base_url) {
+  return Client(std::make_unique<GeminiClient>(get_api_key_or_default(api_key),
+                                               get_base_url_or_default(base_url)));
+}
+
+std::optional<Client> try_create_client() {
+  const char* api_key = std::getenv("GEMINI_API_KEY");
+  if (!api_key) {
+    return std::nullopt;
+  }
+  return Client(std::make_unique<GeminiClient>(api_key, kDefaultBaseUrl));
+}
+
+}  // namespace gemini
+}  // namespace ai

--- a/src/providers/gemini/gemini_factory.h
+++ b/src/providers/gemini/gemini_factory.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "ai/types/client.h"
+
+#include <string>
+#include <optional>
+
+namespace ai {
+namespace gemini {
+
+Client create_client();
+Client create_client(const std::string& api_key);
+Client create_client(const std::string& api_key, const std::string& base_url);
+
+std::optional<Client> try_create_client();
+
+}  // namespace gemini
+}  // namespace ai

--- a/src/providers/gemini/gemini_request_builder.cpp
+++ b/src/providers/gemini/gemini_request_builder.cpp
@@ -1,0 +1,72 @@
+#include "gemini_request_builder.h"
+
+#include "ai/logger.h"
+#include "utils/message_utils.h"
+
+namespace ai {
+namespace gemini {
+
+GeminiRequestBuilder::GeminiRequestBuilder(const providers::ProviderConfig& config)
+    : config_(config) {}
+
+nlohmann::json GeminiRequestBuilder::build_request_json(
+    const GenerateOptions& options) {
+  // If base_url points to Google GL, build the GL payload
+  if (config_.base_url.find("generativelanguage.googleapis.com") != std::string::npos) {
+    nlohmann::json body_json;
+    body_json["contents"] = nlohmann::json::array();
+    nlohmann::json content_obj;
+    content_obj["parts"] = nlohmann::json::array();
+    content_obj["parts"].push_back({{"text", options.prompt.empty() ? options.system : options.prompt}});
+    body_json["contents"].push_back(content_obj);
+    return body_json;
+  }
+
+  // Otherwise, build an OpenAI-compatible request
+  nlohmann::json request{{"model", options.model}, {"messages", nlohmann::json::array()}};
+
+  if (!options.messages.empty()) {
+    for (const auto& msg : options.messages) {
+      nlohmann::json message;
+      message["role"] = utils::message_role_to_string(msg.role);
+      std::string text_content = msg.get_text();
+      if (!text_content.empty()) {
+        message["content"] = text_content;
+      }
+      request["messages"].push_back(message);
+    }
+  } else {
+    if (!options.system.empty()) {
+      request["messages"].push_back({{"role", "system"}, {"content", options.system}});
+    }
+    if (!options.prompt.empty()) {
+      request["messages"].push_back({{"role", "user"}, {"content", options.prompt}});
+    }
+  }
+
+  if (options.temperature) request["temperature"] = *options.temperature;
+  if (options.max_tokens) request["max_completion_tokens"] = *options.max_tokens;
+
+  return request;
+}
+
+nlohmann::json GeminiRequestBuilder::build_request_json(const EmbeddingOptions& options) {
+  nlohmann::json request{{"model", options.model}, {"input", options.input}};
+  return request;
+}
+
+httplib::Headers GeminiRequestBuilder::build_headers(const providers::ProviderConfig& config) {
+  httplib::Headers headers;
+  // If configured for Google GL, use X-goog-api-key
+  if (config.base_url.find("generativelanguage.googleapis.com") != std::string::npos) {
+    headers.emplace("X-goog-api-key", config.api_key);
+  } else {
+    headers.emplace(config.auth_header_name, config.auth_header_prefix + config.api_key);
+  }
+
+  for (const auto& [k, v] : config.extra_headers) headers.emplace(k, v);
+  return headers;
+}
+
+}  // namespace gemini
+}  // namespace ai

--- a/src/providers/gemini/gemini_request_builder.h
+++ b/src/providers/gemini/gemini_request_builder.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "ai/types/embedding_options.h"
+#include "ai/types/generate_options.h"
+#include "providers/base_provider_client.h"
+
+#include <nlohmann/json.hpp>
+
+namespace ai {
+namespace gemini {
+
+class GeminiRequestBuilder : public providers::RequestBuilder {
+ public:
+  explicit GeminiRequestBuilder(const providers::ProviderConfig& config);
+  nlohmann::json build_request_json(const GenerateOptions& options) override;
+  nlohmann::json build_request_json(const EmbeddingOptions& options) override;
+  httplib::Headers build_headers(const providers::ProviderConfig& config) override;
+
+ private:
+  providers::ProviderConfig config_;
+};
+
+}  // namespace gemini
+}  // namespace ai

--- a/src/providers/gemini/gemini_response_parser.cpp
+++ b/src/providers/gemini/gemini_response_parser.cpp
@@ -1,0 +1,89 @@
+#include "gemini_response_parser.h"
+
+#include "ai/logger.h"
+
+namespace ai {
+namespace gemini {
+
+GenerateResult GeminiResponseParser::parse_success_completion_response(const nlohmann::json& response) {
+  // Attempt to parse OpenAI-like structure first
+  try {
+    if (response.contains("choices")) {
+      auto text = response["choices"][0]["message"].value("content", std::string());
+      GenerateResult result;
+      result.text = text;
+      result.finish_reason = kFinishReasonStop;
+      return result;
+    }
+
+    // Try Google GL shape: top-level candidates with content.parts[].text
+    if (response.contains("candidates")) {
+      try {
+        const auto& cand = response["candidates"][0];
+        if (cand.contains("content")) {
+          const auto& content = cand["content"];
+          // If content has parts, join their text fields
+          if (content.contains("parts") && content["parts"].is_array()) {
+            std::string out;
+            for (const auto& part : content["parts"]) {
+              if (part.contains("text") && part["text"].is_string()) {
+                out += part["text"].get<std::string>();
+              }
+            }
+            GenerateResult result;
+            result.text = out;
+            result.finish_reason = kFinishReasonStop;
+            return result;
+          }
+          // Fallback: if content is a string
+          if (content.is_string()) {
+            GenerateResult result;
+            result.text = content.get<std::string>();
+            result.finish_reason = kFinishReasonStop;
+            return result;
+          }
+        }
+      } catch (...) {
+        // fallthrough to generic failure
+      }
+    }
+  } catch (const std::exception& e) {
+    ai::logger::log_error("Gemini parse exception: {}", e.what());
+  }
+
+  return GenerateResult("Failed to parse response");
+}
+
+GenerateResult GeminiResponseParser::parse_error_completion_response(int status_code, const std::string& body) {
+  GenerateResult r;
+  r.error = body;
+  r.finish_reason = kFinishReasonError;
+  r.provider_metadata = std::to_string(status_code);
+  r.is_retryable = false;
+  return r;
+}
+
+EmbeddingResult GeminiResponseParser::parse_success_embedding_response(const nlohmann::json& response) {
+  EmbeddingResult r;
+  // Minimal: look for data[0].embedding
+  try {
+    if (response.contains("data")) {
+      auto emb = response["data"][0]["embedding"].get<std::vector<double>>();
+      r.data = nlohmann::json(emb);
+      return r;
+    }
+  } catch (...) {
+  }
+  r.error = "Failed to parse embedding response";
+  return r;
+}
+
+EmbeddingResult GeminiResponseParser::parse_error_embedding_response(int status_code, const std::string& body) {
+  EmbeddingResult r;
+  r.error = body;
+  r.provider_metadata = std::to_string(status_code);
+  return r;
+}
+
+}  // namespace gemini
+}  // namespace ai

--- a/src/providers/gemini/gemini_response_parser.h
+++ b/src/providers/gemini/gemini_response_parser.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "providers/base_provider_client.h"
+
+#include <nlohmann/json.hpp>
+
+namespace ai {
+namespace gemini {
+
+class GeminiResponseParser : public providers::ResponseParser {
+ public:
+  GenerateResult parse_success_completion_response(const nlohmann::json& response) override;
+  GenerateResult parse_error_completion_response(int status_code, const std::string& body) override;
+  EmbeddingResult parse_success_embedding_response(const nlohmann::json& response) override;
+  EmbeddingResult parse_error_embedding_response(int status_code, const std::string& body) override;
+};
+
+}  // namespace gemini
+}  // namespace ai

--- a/tools/test_gemini_client.cpp
+++ b/tools/test_gemini_client.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+#include <ai/ai.h>
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cerr << "Usage: test_gemini_client <api_key>\n";
+    return 2;
+  }
+  std::string key = argv[1];
+  auto client = ai::gemini::create_client(key);
+  std::cout << "client.is_valid()=" << client.is_valid() << "\n";
+  std::cout << "provider_name=" << client.provider_name() << "\n";
+  std::cout << "default_model=" << client.default_model() << "\n";
+  std::cout << "config_info=" << client.config_info() << "\n";
+  return 0;
+}


### PR DESCRIPTION
Usage
-
- Set provider API key (GUC) in your psql session and call `pg_gen_query` with a natural language prompt.

```sql
SET pg_gen_query.gemini_api_key = 'YOUR_GEMINI_API_KEY';
SELECT pg_gen_query('number of events from Texas');
```

Features
-
- Schema-aware prompts: includes a concise list of non-system tables and columns in the prompt.
- Provider support: Gemini (primary) with optional fallbacks to OpenAI/Anthropic.
- Auto-execute read-only: executes returned SQL only when it begins with `SELECT`.
- Preview-only: returns generated SQL without executing when not a `SELECT`.

Build & Install
-
- From `contrib/pg_gen_query`:

```fish
mkdir -p build && cd build
cmake .. -DCMAKE_PREFIX_PATH=/path/to/ai-sdk-cpp/build/install
cmake --build . --config Release
```

- Copy the built library into your Postgres extension directory (example Homebrew path):

```fish
cp build/pg_gen_query.so /opt/homebrew/lib/postgresql@14/
```

- Then in `psql` create/load the extension and set GUCs as needed.

Examples (exact commands and results)

Run the setup and insert the sample rows (API key masked):

```fish
psql -d postgres -c "SET client_min_messages = 'log'; SET pg_gen_query.gemini_model = 'gemini-2.0-flash'; SET pg_gen_query.gemini_api_key = 'YOUR_GEMINI_API_KEY'; DROP TABLE IF EXISTS events; CREATE TABLE events(id serial primary key, name text, state text); TRUNCATE events; INSERT INTO events(name,state) VALUES('Concert','Texas'),('Meetup','Texas'),('Conference','California'),('Webinar','Texas'),('Hackathon','New York');"
```

Run each example query (these are the exact commands used during testing) and the expected outputs shown after each:

```sql
-- 1) Count Texas events
SELECT pg_gen_query('number of events from Texas');
-- Generated SQL (example):
-- SELECT COUNT(*) AS count FROM events WHERE state = 'Texas';
-- Result (example):
-- count
-- ------
-- 3

-- 2) List events in California
SELECT pg_gen_query('list events in California');
-- Generated SQL (example):
-- SELECT * FROM events WHERE state = 'California';
-- Result (example):
-- id | name       | state
-- ---+------------+-----------
-- 3  | Conference | California

-- 3) Names of events in New York
SELECT pg_gen_query('return the names of events in New York');
-- Generated SQL (example):
-- SELECT name FROM events WHERE state = 'New York';
-- Result (example):
-- name
-- -------
-- Hackathon
```